### PR TITLE
Fix: vercel.json conflict (remove routes)

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -8,8 +8,5 @@
       "memory": 128
     }
   },
-  "buildCommand": "echo 'No build step'",
-  "routes": [
-    { "src": "/", "dest": "/index.html" }
-  ]
+  "buildCommand": "echo 'No build step'"
 }


### PR DESCRIPTION
Fix Vercel config error: “If rewrites, redirects, headers, cleanUrls or trailingSlash are used, then routes cannot be present.”

- Remove legacy `routes` from `vercel.json` and keep `cleanUrls`/`trailingSlash`.
- Keep Node.js 20 runtime and no-op `buildCommand` to avoid Next.js autodetection.

Merging this will unblock builds on main.


₍ᐢ•(ܫ)•ᐢ₎ Generated by [Capy](https://capy.ai) ([view task](https://capy.ai/project/572eae53-84af-11f0-a94e-3eef481a796b/task/b062a1fa-cbc3-4ce0-a63b-a07916cb0ae0))